### PR TITLE
Adding Infracost as part of terraform plan

### DIFF
--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -24,7 +24,7 @@ on:
       INFRACOST_API_KEY:
         description: " The Infracost API key for requests to the Infracost API"
         required: true
-        
+
 jobs:
   terraform-plan:
     name: "Plan"
@@ -115,16 +115,19 @@ jobs:
         id: cost-estimate
         run: |
           set -x
-          infracost -v 
+          export prefix="::set-output name=exitcode::"
 
-          infracost breakdown --path ./terraform-${{ matrix.workspace }}.json \
+          bash -c '(infracost breakdown --path ./terraform-${{ matrix.workspace }}.json \
           --format json \
-          --out-file infracost-${{ matrix.workspace }}.json
+          --out-file infracost-${{ matrix.workspace }}.json 2> infracost-${{ matrix.workspace }}-stdderr.txt \
+          && echo "${prefix}${?}") || echo "${prefix}${?}"'
 
-          infracost output --path infracost-${{ matrix.workspace }}.json \
+          bash -c '(infracost output --path infracost-${{ matrix.workspace }}.json \
           --format github-comment \
           --show-skipped \
-          --out-file infracost-${{ matrix.workspace }}.md
+          --out-file infracost-${{ matrix.workspace }}.md 2> infracost-${{ matrix.workspace }}-stdderr.txt \
+          && echo "${prefix}${?}") || echo "${prefix}${?}"'
+          
         continue-on-error: true
 
       - name: Output Plan

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -112,6 +112,8 @@ jobs:
         id: cost-estimate
         run: |
           set -x
+          infracost -v 
+          
           infracost breakdown --path terraform-${{ matrix.workspace }}.json \
           --format json \
           --out-file infracost-${{ matrix.workspace }}.json 2> infracost-${{ matrix.workspace }}-stderr.txt

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -122,7 +122,7 @@ jobs:
           export prefix="::set-output name=exitcode::"
           USAGE_FILE=$([ -z "${{ inputs.cost_usage_file }}" ] && echo "" || echo "--usage-file ${{ inputs.cost_usage_file }}")
 
-          bash -c '(infracost breakdown ${USAGE_FILE} --path ./terraform-${{ matrix.workspace }}.json \
+          bash -c '(infracost breakdown "${USAGE_FILE}" --path ./terraform-${{ matrix.workspace }}.json \
           --format json \
           --out-file infracost.json 2> infracost-stderr.txt \
           && echo "${prefix}${?}") || echo "${prefix}${?}"'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -104,7 +104,7 @@ jobs:
             && echo "${prefix}${?}") || echo "${prefix}${?}"'
           cat terraform-${{ matrix.workspace }}-stderr.txt
           terraform show -no-color terraform-${{ matrix.workspace }}.plan > terraform-${{ matrix.workspace }}.txt
-          terraform show -json terraform-${{ matrix.workspace }}.plan > terrform-${{ matrix.workspace }}.json 
+          terraform show -json terraform-${{ matrix.workspace }}.plan > terraform-${{ matrix.workspace }}.json 
           cat terraform-${{ matrix.workspace }}.txt | tail -c 65000 > trunc_plan.txt
         continue-on-error: true
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -11,6 +11,10 @@ on:
         description: "A JSON list of objects that include include a workspace key/value."
         required: true
         type: string
+      cost_usage_file:
+        description: "A YAML file containing cloud resource usage estimates for Infracost"
+        required: false
+        type: string 
     secrets:
       AWS_ACCESS_KEY_ID:
         description: "The AWS Access Key ID for writing to the backend and managing resources."
@@ -116,18 +120,18 @@ jobs:
         run: |
           set -x
           export prefix="::set-output name=exitcode::"
+          USAGE_FILE=$([ -z "${{ inputs.cost_usage_file }}" ] && echo "" || echo "--usage-file ${{ inputs.cost_usage_file }}")
 
-          bash -c '(infracost breakdown --path ./terraform-${{ matrix.workspace }}.json \
+          bash -c '(infracost breakdown "${USAGE_FILE}" --path ./terraform-${{ matrix.workspace }}.json \
           --format json \
-          --out-file infracost-${{ matrix.workspace }}.json 2> infracost-${{ matrix.workspace }}-stdderr.txt \
+          --out-file infracost.json 2> infracost-stderr.txt \
           && echo "${prefix}${?}") || echo "${prefix}${?}"'
 
-          bash -c '(infracost output --path infracost-${{ matrix.workspace }}.json \
+          bash -c '(infracost output --path infracost.json \
           --format github-comment \
           --show-skipped \
-          --out-file infracost-${{ matrix.workspace }}.md 2> infracost-${{ matrix.workspace }}-stdderr.txt \
+          --out-file infracost.md 2> infracost-stdderr.txt \
           && echo "${prefix}${?}") || echo "${prefix}${?}"'
-          
         continue-on-error: true
 
       - name: Output Plan

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -113,15 +113,15 @@ jobs:
         run: |
           set -x
           infracost -v 
-          
-          infracost breakdown --path terraform-${{ matrix.workspace }}.json \
+
+          infracost breakdown --path ./terraform-${{ matrix.workspace }}.json \
           --format json \
-          --out-file infracost-${{ matrix.workspace }}.json 2> infracost-${{ matrix.workspace }}-stderr.txt
+          --out-file infracost-${{ matrix.workspace }}.json
 
           infracost output --path infracost-${{ matrix.workspace }}.json \
           --format github-comment \
           --show-skipped \
-          --out-file infracost-${{ matrix.workspace }}.md 2> infracost-${{ matrix.workspace }}-stderr.txt
+          --out-file infracost-${{ matrix.workspace }}.md
         continue-on-error: true
 
       - name: Output Plan

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -114,12 +114,12 @@ jobs:
           set -x
           infracost breakdown --path terraform-${{ matrix.workspace }}.json \
           --format json \
-          --out-file infracost-${{ matrix.workspace }}.json 2> infracost-$${{ matrix.workspace }}-stderr.txt
+          --out-file infracost-${{ matrix.workspace }}.json 2> infracost-${{ matrix.workspace }}-stderr.txt
 
           infracost output --path infracost-${{ matrix.workspace }}.json \
           --format github-comment \
           --show-skipped \
-          --out-file infracost-${{ matrix.workspace }}.md 2> infracost-$${{ matrix.workspace }}-stderr.txt
+          --out-file infracost-${{ matrix.workspace }}.md 2> infracost-${{ matrix.workspace }}-stderr.txt
         continue-on-error: true
 
       - name: Output Plan
@@ -133,9 +133,9 @@ jobs:
               fs.readFileSync("./terraform-${{ matrix.workspace }}-stderr.txt").toString() :
               fs.readFileSync("./trunc_plan.txt").toString();
             const plan_outcome = (${{ steps.plan.outputs.exitcode }} == 0) ? "no changes" : "${{ steps.plan.outcome }}";
-            const infracost_outcome = (${{ steps.cost-estimate.outputs.exitcode }} == 1)?
+            const infracost_outcome = (${{ steps.cost-estimate.outputs.exitcode }} == 1) ?
               fs.readFileSync("./infracost-${{ matrix.workspace }}-stderr.txt").toString() :
-              fs.readFileSynce("./infracost-${{ matrix.workspace }}.md").toString();
+              fs.readFileSync("./infracost-${{ matrix.workspace }}.md").toString();
         
             const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Plan 📖\`${plan_outcome}\`
@@ -149,7 +149,7 @@ jobs:
             </details>
 
             ### Infracost Breakdown 
-            ${ infracost_outcome }
+            ${infracost_outcome}
 
             *Pusher: @${{ github.actor }}, Workspace: \`${{ matrix.workspace }}\`*`;
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -104,7 +104,7 @@ jobs:
             && echo "${prefix}${?}") || echo "${prefix}${?}"'
           cat terraform-${{ matrix.workspace }}-stderr.txt
           terraform show -no-color terraform-${{ matrix.workspace }}.plan > terraform-${{ matrix.workspace }}.txt
-          terraform show -json terraform-${{ matrix.workspace }}.json > terrform-${{ matrix.workspace }}.json 
+          terraform show -json terraform-${{ matrix.workspace }}.plan > terrform-${{ matrix.workspace }}.json 
           cat terraform-${{ matrix.workspace }}.txt | tail -c 65000 > trunc_plan.txt
         continue-on-error: true
 
@@ -112,7 +112,7 @@ jobs:
         id: cost-estimate
         run: |
           set -x
-          infracost breakdown --path terrafom-${{ matrix.workspace }}.json \
+          infracost breakdown --path terraform-${{ matrix.workspace }}.json \
           --format json \
           --out-file infracost-${{ matrix.workspace }}.json 2> infracost-$${{ matrix.workspace }}-stderr.txt
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -122,7 +122,7 @@ jobs:
           export prefix="::set-output name=exitcode::"
           USAGE_FILE=$([ -z "${{ inputs.cost_usage_file }}" ] && echo "" || echo "--usage-file ${{ inputs.cost_usage_file }}")
 
-          bash -c '(infracost breakdown "${USAGE_FILE}" --path ./terraform-${{ matrix.workspace }}.json \
+          bash -c '(infracost breakdown ${USAGE_FILE} --path ./terraform-${{ matrix.workspace }}.json \
           --format json \
           --out-file infracost.json 2> infracost-stderr.txt \
           && echo "${prefix}${?}") || echo "${prefix}${?}"'
@@ -146,8 +146,8 @@ jobs:
               fs.readFileSync("./trunc_plan.txt").toString();
             const plan_outcome = (${{ steps.plan.outputs.exitcode }} == 0) ? "no changes" : "${{ steps.plan.outcome }}";
             const infracost_outcome = (${{ steps.cost-estimate.outputs.exitcode }} == 1) ?
-              fs.readFileSync("./infracost-${{ matrix.workspace }}-stderr.txt").toString() :
-              fs.readFileSync("./infracost-${{ matrix.workspace }}.md").toString();
+              fs.readFileSync("./infracost-stderr.txt").toString() :
+              fs.readFileSync("./infracost.md").toString();
         
             const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Plan 📖\`${plan_outcome}\`

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -21,7 +21,10 @@ on:
       GITHUB_PAT:
         description: "A GitHub PAT used to initialize private submodules"
         required: false
-
+      INFRACOST_API_KEY:
+        description: " The Infracost API key for requests to the Infracost API"
+        required: true
+        
 jobs:
   terraform-plan:
     name: "Plan"

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -73,6 +73,12 @@ jobs:
           terraform_version: ${{ steps.set-terraform-version.outputs.terraform-version}}
           terraform_wrapper: false
 
+      - name: Infracost Setup
+        uses: infracost/actions/setup@v1.1.1
+        with:
+          api-key: ${{ secrets.INFRACOST_API_KEY }}
+          currency: CAD
+          
       - name: Terraform Init
         id: init
         run: |
@@ -98,7 +104,22 @@ jobs:
             && echo "${prefix}${?}") || echo "${prefix}${?}"'
           cat terraform-${{ matrix.workspace }}-stderr.txt
           terraform show -no-color terraform-${{ matrix.workspace }}.plan > terraform-${{ matrix.workspace }}.txt
+          terraform show -json terraform-${{ matrix.workspace }}.plan > terrform-${{ matrix.workspace }}.json 
           cat terraform-${{ matrix.workspace }}.txt | tail -c 65000 > trunc_plan.txt
+        continue-on-error: true
+
+      - name: Infracost cost estimate
+        id: cost-estimate
+        run: |
+          set -x
+          infracost breakdown --path terrafom-${{ matrix.workspace }}.json \
+          --format json \
+          --out-file infracost-${{ matrix.workspace }}.json 2> infracost-$${{ matrix.workspace }}-stderr.txt
+
+          infracost output --path infracost-${{ matrix.workspace }}.json \
+          --format github-comment \
+          --show-skipped \
+          --out-file infracost-${{ matrix.workspace }}.md 2> infracost-$${{ matrix.workspace }}-stderr.txt
         continue-on-error: true
 
       - name: Output Plan
@@ -112,6 +133,10 @@ jobs:
               fs.readFileSync("./terraform-${{ matrix.workspace }}-stderr.txt").toString() :
               fs.readFileSync("./trunc_plan.txt").toString();
             const plan_outcome = (${{ steps.plan.outputs.exitcode }} == 0) ? "no changes" : "${{ steps.plan.outcome }}";
+            const infracost_outcome = (${{ steps.cost-estimate.outputs.exitcode }} == 1)?
+              fs.readFileSync("./infracost-${{ matrix.workspace }}-stderr.txt").toString() :
+              fs.readFileSynce("./infracost-${{ matrix.workspace }}.md").toString();
+        
             const output = `#### Terraform Initialization ⚙️\`${{ steps.init.outcome }}\`
             #### Terraform Plan 📖\`${plan_outcome}\`
 
@@ -122,6 +147,9 @@ jobs:
             \`\`\`
 
             </details>
+
+            ### Infracost Breakdown 
+            ${ infracost_outcome }
 
             *Pusher: @${{ github.actor }}, Workspace: \`${{ matrix.workspace }}\`*`;
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -111,7 +111,7 @@ jobs:
             && echo "${prefix}${?}") || echo "${prefix}${?}"'
           cat terraform-${{ matrix.workspace }}-stderr.txt
           terraform show -no-color terraform-${{ matrix.workspace }}.plan > terraform-${{ matrix.workspace }}.txt
-          terraform show -json terraform-${{ matrix.workspace }}.plan > terraform-${{ matrix.workspace }}.json 
+          terraform show -json terraform-${{ matrix.workspace }}.plan > plan.json 
           cat terraform-${{ matrix.workspace }}.txt | tail -c 65000 > trunc_plan.txt
         continue-on-error: true
 
@@ -122,7 +122,7 @@ jobs:
           export prefix="::set-output name=exitcode::"
           USAGE_FILE=$([ -z "${{ inputs.cost_usage_file }}" ] && echo "" || echo "--usage-file ${{ inputs.cost_usage_file }}")
 
-          bash -c '(infracost breakdown "${USAGE_FILE}" --path ./terraform-${{ matrix.workspace }}.json \
+          bash -c '(infracost breakdown "${USAGE_FILE}" --path ./plan.json \
           --format json \
           --out-file infracost.json 2> infracost-stderr.txt \
           && echo "${prefix}${?}") || echo "${prefix}${?}"'

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -104,7 +104,7 @@ jobs:
             && echo "${prefix}${?}") || echo "${prefix}${?}"'
           cat terraform-${{ matrix.workspace }}-stderr.txt
           terraform show -no-color terraform-${{ matrix.workspace }}.plan > terraform-${{ matrix.workspace }}.txt
-          terraform show -json terraform-${{ matrix.workspace }}.plan > terrform-${{ matrix.workspace }}.json 
+          terraform show -json terraform-${{ matrix.workspace }}.json > terrform-${{ matrix.workspace }}.json 
           cat terraform-${{ matrix.workspace }}.txt | tail -c 65000 > trunc_plan.txt
         continue-on-error: true
 

--- a/.github/workflows/plan.yml
+++ b/.github/workflows/plan.yml
@@ -11,7 +11,7 @@ on:
         description: "A JSON list of objects that include include a workspace key/value."
         required: true
         type: string
-      cost_usage_file:
+      infracost_usage_file:
         description: "A YAML file containing cloud resource usage estimates for Infracost"
         required: false
         type: string 
@@ -120,7 +120,7 @@ jobs:
         run: |
           set -x
           export prefix="::set-output name=exitcode::"
-          USAGE_FILE=$([ -z "${{ inputs.cost_usage_file }}" ] && echo "" || echo "--usage-file ${{ inputs.cost_usage_file }}")
+          USAGE_FILE=$([ -z "${{ inputs.infracost_usage_file }}" ] && echo "" || echo "--usage-file ${{ inputs.infracost_usage_file }}")
 
           bash -c '(infracost breakdown "${USAGE_FILE}" --path ./plan.json \
           --format json \

--- a/README.md
+++ b/README.md
@@ -50,6 +50,10 @@ jobs:
 
 Plans are run when a pull request is open.
 
+Within the `terraform-plan` workflow, Infracost is ran to provide a cost estimate in the pull request. 
+
+The optional parameter `infracost_usage_file` is a YAML file that contains usage estimates for usage-based resources.
+
 ```yaml
 # .github/workflows/tf-plan.yml
 name: terraform-plan
@@ -81,10 +85,12 @@ jobs:
     with:
       config: ${{ needs.read-terraform-config.outputs.staging_config }}
       profile: staging
+      infracost_usage_file: infracost.yml # OPTIONAL parameter
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.MY_AWS_ACCESS_KEY_ID_STAGING }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MY_AWS_SECRET_ACCESS_KEY_STAGING }}
       GITHUB_PAT: ${{ secrets.MY_GITHUB_PAT }}
+      INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
 
   terraform-plan-production:
     name: "Terraform"
@@ -93,10 +99,12 @@ jobs:
     with:
       config: ${{ needs.read-terraform-config.outputs.production_config }}
       profile: production
+      infracost_usage_file: infracost.yml # OPTIONAL parameter
     secrets:
       AWS_ACCESS_KEY_ID: ${{ secrets.MY_AWS_ACCESS_KEY_ID_STAGING }}
       AWS_SECRET_ACCESS_KEY: ${{ secrets.MY_AWS_SECRET_ACCESS_KEY_STAGING }}
       GITHUB_PAT: ${{ secrets.MY_GITHUB_PAT }}
+      INFRACOST_API_KEY: ${{ secrets.INFRACOST_API_KEY }}
 ```
 
 ### Apply


### PR DESCRIPTION
Changes here adds Infracost as part of the `terraform plan` workflow. 

Cost estimates are based off of the changes detected from `terraform plan`. 

For resources where costs vary depending on the usage, an additional YAML file with usage estimates can be provided for more accurate cost estimates.  This example PR shows the output from Infracost and how they will appear in the PR - https://github.com/rewindio/terraform-sourcegraph/pull/29